### PR TITLE
EANA-532: Add bypass delete confirm for content as well

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -304,7 +304,7 @@ func (app *App) executeOperations(manifest Manifest) error {
 		if operation.Config.Type == "content" {
 			var args []string
 			if operation.Action == "delete" {
-				args = []string{"mim", "content", "delete", operation.Config.Id}
+				args = []string{"mim", "content", "delete", operation.Config.Id, "-C=false"}
 			} else {
 				args = []string{"mim", "content", "add", "-f", tmpFileName}
 			}


### PR DESCRIPTION
Was only jobs who could delete since the -C=false was missing from content. Content can now be deleted without prompt.