### PR TITLE
Add support for public namespace and dataset upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,47 @@ If you need to define public namespaces for the dataset used by the sink, this c
 ```
 If the dataset is already created, the dataset will be updated with the defined public namespaces.
 
+#### Create dataset and upload entities stored in your config
+In some cases we need to datasets that we manually create and can't be read from a different source. This can be achieved by adding files under the `dataset` directory.
+Files in there need to structured like this:
+
+```json
+{
+    "type": "dataset",
+    "datasetName": "cima.AnimalType",
+    "publicNamespaces": [],
+    "entities": [
+        {
+            "id": "@context",
+            "namespaces": {
+                "ns1": "http://data.mimiro.io/cima/",
+                "ns2": "http://data.mimiro.io/sdb/animaltype/",
+                "ns3": "http://www.w3.org/2000/01/rdf-schema#"
+            }
+        },
+        {
+            "id": "ns2:cow",
+            "refs": {
+                "ns3:type": "ns1:AnimalType"
+            },
+            "props": {
+                "ns1:name": "Cow"
+            }
+        },
+        {
+            "id": "ns2:pig",
+            "refs": {
+                "ns3:type": "ns1:AnimalType"
+            },
+            "props": {
+                "ns1:name": "Pig"
+            }
+        }
+    ]
+}
+
+```
+
 ## How to run
 
 The following configuration properties can either be set by environment variables or by changing the .env file

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Based on the comparison, it creates a list of operations and utilizes the [mim c
 │   │   └── content-s3.json
 │   └── mysystem
 │       └── content-mysystem.json
+├── dataset
+│   ├── myfolder
+│   │   └── my-dataset.json
+│   └── my-other-dataset.json
 ├── environments
 │   ├── variables-dev.json
 │   ├── variables-prod.json
@@ -25,7 +29,7 @@ Based on the comparison, it creates a list of operations and utilizes the [mim c
 ```
 
 ## Required configuration changes
-* Jobs and contents need a type property with either "job" or "content" as value.
+* Jobs and content need a type property with either "job" or "content" as value.
 * Jobs with transform need to have a "path" property containing the relative path for the transform file inside the transform directory.
 ```json
 {
@@ -119,6 +123,24 @@ To ignore specific paths from being deployed add the environment variable:
 --ignorePath ../datahub-config/<path_to_ignore>
 ```
 to your bash command
+
+### Dataset creation and public namespaces
+When you define a `DatasetSink`, the named dataset will be created when the configuration is deployed to the datahub.
+
+**Public namespaces**
+
+If you need to define public namespaces for the dataset used by the sink, this can be defined in the job like this.
+```json
+    "sink": {
+        "Type": "DatasetSink",
+        "Name": "mysystem.Owner",
+        "publicNamespaces": [
+            "http://data.mimiro.io/owner/event/",
+            "http://data.mimiro.io/people/birthdate/"
+        ]
+    }
+```
+If the dataset is already created, the dataset will be updated with the defined public namespaces.
 
 ## How to run
 

--- a/internal/app/environment/environment.go
+++ b/internal/app/environment/environment.go
@@ -29,7 +29,7 @@ func (env *Environment) GetConfigFiles() ([]string, error) {
 		if err != nil {
 			return err
 		}
-		if info.IsDir() && contains(env.IgnorePath, path){
+		if info.IsDir() && contains(env.IgnorePath, path) {
 			pterm.Info.Println("ignoring path ", path)
 			return filepath.SkipDir
 		}
@@ -70,6 +70,8 @@ func (env *Environment) GetConfigType(path string) string {
 		return "content"
 	case "transforms":
 		return "transform"
+	case "dataset":
+		return "dataset"
 	default:
 		return "unknown"
 

--- a/internal/app/mim.go
+++ b/internal/app/mim.go
@@ -1,0 +1,92 @@
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/mimiro-io/datahub-config-deployment/internal/app/environment"
+	"github.com/mimiro-io/datahub-config-deployment/internal/utils"
+	"github.com/pterm/pterm"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type MimConfig struct {
+	Env        *environment.Environment
+	CmdOutputs []string
+}
+
+func NewMim(env *environment.Environment) *MimConfig {
+	return &MimConfig{Env: env}
+}
+
+func (m *MimConfig) MimCommand(cmd []string) ([]byte, error) {
+	cmdExec := exec.Command("/bin/bash", "-c", fmt.Sprintf("%s", strings.Join(cmd, " ")))
+
+	if m.Env.DryRun {
+		return nil, nil
+	}
+
+	return cmdExec.CombinedOutput()
+}
+
+func (m *MimConfig) MimDatasetStore(datasetName string, payload []byte) ([]byte, error) {
+	tmpFilename := "tmp_entity"
+	cmd := []string{"mim", "dataset", "store", datasetName, "-f", tmpFilename}
+	err := ioutil.WriteFile(tmpFilename, payload, 0644)
+	if err != nil {
+		pterm.Error.Println("Failed to write entity to temp file")
+		return nil, err
+	}
+	m.CmdOutputs = append(m.CmdOutputs, strings.Join(cmd, " "))
+	utils.LogCommand(cmd, m.Env.LogFormat, "")
+	output, err := m.MimCommand(cmd)
+	err2 := os.Remove(tmpFilename)
+	if err2 != nil {
+		pterm.Error.Println("Failed to remove tmp file for core entity")
+		return nil, err2
+	}
+
+	return output, err
+}
+
+func (m *MimConfig) MimDatasetDelete(datasetName string) error {
+	cmd := []string{"mim", "dataset", "delete", datasetName, "-C=false"}
+	m.CmdOutputs = append(m.CmdOutputs, strings.Join(cmd, " "))
+	utils.LogCommand(cmd, m.Env.LogFormat, "")
+	output, err := m.MimCommand(cmd)
+	if err != nil {
+		pterm.Error.Printf("Failed to delete dataset '%s':\n%s\n", datasetName, string(output))
+		return err
+	}
+	return nil
+}
+
+func (m *MimConfig) MimDatasetGet(datasetName string) (DatasetResponse, error) {
+	cmd := []string{"mim", "dataset", "get", datasetName, "--json"}
+	output, err := m.MimCommand(cmd)
+	var dataset DatasetResponse
+	if err != nil {
+		pterm.Error.Printf("Failed to get dataset '%s' from datahub: %s\n", datasetName, string(output))
+		return dataset, err
+	}
+	json.Unmarshal(output, dataset)
+	return dataset, nil
+}
+
+func (m *MimConfig) MimDatasetCreate(datasetName string, publicNamespaces []string) error {
+	cmd := []string{"mim", "dataset", "create", datasetName}
+	if len(publicNamespaces) > 0 {
+		cmd = []string{"mim", "dataset", "create", datasetName, "--publicNamespaces", fmt.Sprintf("'%s'", strings.Join(publicNamespaces, "','"))}
+	}
+	m.CmdOutputs = append(m.CmdOutputs, strings.Join(cmd, " "))
+	utils.LogCommand(cmd, m.Env.LogFormat, "")
+	output, err := m.MimCommand(cmd)
+	if err != nil {
+		pterm.Error.Println("Failed to create dataset in datahub: ", string(output))
+		return err
+	}
+	return nil
+
+}

--- a/internal/utils/util.go
+++ b/internal/utils/util.go
@@ -4,12 +4,10 @@ import (
 	"bufio"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"github.com/pterm/pterm"
 	"io"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"strings"
 )
 
@@ -18,12 +16,6 @@ type ErrorDetails struct {
 	Line    int
 	Col     int
 	Message string
-}
-
-type DatasetResponse struct {
-	Items            int      `json:"items"`
-	Name             string   `json:"name"`
-	PublicNamespaces []string `json:"publicNamespaces"`
 }
 
 func HandleError(err error) {
@@ -147,67 +139,4 @@ func LogError(error ErrorDetails, logFormat string) {
 	default:
 		pterm.DefaultParagraph.Println(error.Message)
 	}
-}
-
-func MimCommand(cmd []string, logFormat string, dryRun bool) ([]byte, error) {
-	cmdExec := exec.Command("/bin/bash", "-c", fmt.Sprintf("%s", strings.Join(cmd, " ")))
-	LogCommand(cmd, logFormat, "")
-	if dryRun {
-		return nil, nil
-	}
-	return cmdExec.CombinedOutput()
-}
-
-func MimDatasetStore(datasetName string, payload []byte, logFormat string, dryRun bool) error {
-	tmpFilename := "tmp_entity"
-	cmd := []string{"mim", "dataset", "store", datasetName, "-f", tmpFilename}
-	err := ioutil.WriteFile(tmpFilename, payload, 0644)
-	if err != nil {
-		pterm.Error.Println("Failed to write entity to temp file")
-		return err
-	}
-	_, err = MimCommand(cmd, logFormat, dryRun)
-	err2 := os.Remove(tmpFilename)
-	if err2 != nil {
-		pterm.Error.Println("Failed to remove tmp file for core entity")
-		return err2
-	}
-
-	return err
-}
-
-func MimDatasetDelete(datasetName string, logFormat string, dryRun bool) error {
-	cmd := []string{"mim", "dataset", "delete", datasetName, "-C=false"}
-	output, err := MimCommand(cmd, logFormat, dryRun)
-	if err != nil {
-		pterm.Error.Printf("Failed to delete dataset '%s':\n%s\n", datasetName, string(output))
-		return err
-	}
-	return nil
-}
-
-func MimDatasetGet(datasetName string, logFormat string, dryRun bool) (DatasetResponse, error) {
-	cmd := []string{"mim", "dataset", "get", datasetName, "--json"}
-	output, err := MimCommand(cmd, logFormat, dryRun)
-	var dataset DatasetResponse
-	if err != nil {
-		pterm.Error.Printf("Failed to get dataset '%s' from datahub: %s\n", datasetName, string(output))
-		return dataset, err
-	}
-	json.Unmarshal(output, dataset)
-	return dataset, nil
-}
-
-func MimDatasetCreate(datasetName string, publicNamespaces []string, logFormat string, dryRun bool) error {
-	cmd := []string{"mim", "dataset", "create", datasetName}
-	if len(publicNamespaces) > 0 {
-		cmd = []string{"mim", "dataset", "create", datasetName, "--publicNamespaces", fmt.Sprintf("'%s'", strings.Join(publicNamespaces, "','"))}
-	}
-	output, err := MimCommand(cmd, logFormat, dryRun)
-	if err != nil {
-		pterm.Error.Println("Failed to create dataset in datahub: ", string(output))
-		return err
-	}
-	return nil
-
 }


### PR DESCRIPTION
* This will allow you to define public namespaces for the sink dataset on the job config. 
* Add support for a new dataset directory to allow for auto creation and uploading of entities stored in the config repo.